### PR TITLE
Make Limit an optional parameter to the lib's clan search call

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -900,10 +900,14 @@ Khan API
 
   Results are limited by "search.pageSize" set via config YAML or environment variable KHAN\_SEARCH\_PAGESIZE
 
+  The `limit` parameter can be used as a custom pageSize
+
   * URL Parameters
 
     ```
       term=[string]
+      from=[int]
+      limit=[int]
     ```
 
   * Success Response

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -265,9 +265,15 @@ func (k *Khan) buildSearchClansURL(clanName string) string {
 	return k.buildURL(pathname)
 }
 
-func (k *Khan) buildSearchClansWithOptionsURL(clanName string, searchMethod SearchMethod, from, limit int) string {
+func (k *Khan) buildSearchClansWithOptionsURL(clanName string, searchMethod SearchMethod, from int, limit *OptionalInt) string {
+	var pathname string
 	useRegexSearch := searchMethod == SearchMethodRegex
-	pathname := fmt.Sprintf("clans/search?term=%s&useRegexSearch=%t&from=%d&limit=%d", clanName, useRegexSearch, from, limit)
+	if limit == nil {
+		pathname = fmt.Sprintf("clans/search?term=%s&useRegexSearch=%t&from=%d", clanName, useRegexSearch, from)
+	} else {
+		pathname = fmt.Sprintf("clans/search?term=%s&useRegexSearch=%t&from=%d&limit=%d", clanName, useRegexSearch, from, limit.Value)
+	}
+
 	return k.buildURL(pathname)
 }
 

--- a/lib/models.go
+++ b/lib/models.go
@@ -234,8 +234,12 @@ const (
 	SearchMethodRegex
 )
 
+type OptionalInt struct {
+	Value int
+}
+
 type SearchOptions struct {
 	Method SearchMethod
-	Limit  int
+	Limit  *OptionalInt
 	From   int
 }


### PR DESCRIPTION
- Make Limit an optional parameter to the lib's clan search call
- improve documentation regarding clan search